### PR TITLE
Fix SWMProg with Python 3.10 (fedora 36)

### DIFF
--- a/SWMProg.ui
+++ b/SWMProg.ui
@@ -281,7 +281,7 @@
      <item>
       <widget class="QPushButton" name="btnWrite">
        <property name="text">
-        <string>擦写</string>
+        <string>烧录</string>
        </property>
       </widget>
      </item>

--- a/pyocd/utility/sequencer.py
+++ b/pyocd/utility/sequencer.py
@@ -14,7 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import (OrderedDict, Callable)
+import sys
+if sys.version_info >= (3,10):
+    from collections.abc import (Callable)
+    from collections import (OrderedDict)
+else:
+    from collections import (OrderedDict, Callable)
+
 import logging
 
 log = logging.getLogger("sequencer")


### PR DESCRIPTION
The SWMProg can be used under linux, it can erase / program and read firmware from target device.

At lease for Python version 3.10, these changes are needed.